### PR TITLE
Resolve apt-utils error

### DIFF
--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -11,7 +11,7 @@ spec:
         - echo 'Greenwell Site - Health Check';
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           sleep 15;
-          apt-get -qq update > /dev/null; apt-get -qq -y install curl > /dev/null;
+          apt-get -qq update > /dev/null; apt-get -qq -y install --no-install-recommends apt-utils > /dev/null; apt-get -qq -y install curl > /dev/null;
           alive=$(curl https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;


### PR DESCRIPTION
`debconf: delaying package configuration, since apt-utils is not installed` error is appearing in pipeline runs, and possibly causing failures on DEV e2e runs. Seems to be an [underlying issue in ubuntu image](https://github.com/phusion/baseimage-docker/issues/319)