### PR TITLE
Improve script output

### DIFF
--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -11,8 +11,9 @@ spec:
         - echo "=======================";
           echo "Greenwell Site - Health Check";
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
+          echo "Endpoint - https://greenwell-app.eu-de.mybluemix.net/health";
           echo "=======================";
-          alive=$(curl -s -S -k https://greenwell-app.eu-de.mybluemix.net/health404);
+          alive=$(curl -s -S -k https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;
           else echo "TEST FAIL - $alive"; exit 1;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -8,15 +8,13 @@ spec:
       image: ubuntu
       command: ["bash", "-c"]
       args:
-        - apt-get -qq update;
-          echo "apt-get update complete";
-          apt-get -qq -y install apt-utils 2> >( grep -v 'debconf: delaying package configuration, since apt-utils is not installed' >&2 );
-          echo "apt-utils install complete";
-          apt-get -qq -y --no-install-recommends install curl;
-          echo "curl install complete";
+        - apt-get -qq update > /dev/null;
+          apt-get -qq -y install apt-utils > /dev/null;
+          apt-get -qq -y --no-install-recommends install curl > /dev/null;
           echo "=======================";
           echo "Greenwell Site - Health Check";
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
+          echo "=======================";
           alive=$(curl https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -12,8 +12,6 @@ spec:
           echo "Greenwell Site - Health Check";
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           echo "=======================";
-          dnf list installed;
-          dnf -y install curl;
           alive=$(curl -k https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -12,8 +12,9 @@ spec:
           echo "Greenwell Site - Health Check";
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           echo "=======================";
-          alive=$(curl -k https://greenwell-app.eu-de.mybluemix.net/health);
+          alive=$(curl -s -S -k https://greenwell-app.eu-de.mybluemix.net/health);
           echo "=======================";
+          echo $alive
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;
           else echo "TEST FAIL - $alive"; exit 1;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   steps:
     - name: task-one-step-one
-      image: debian
+      image: ubuntu
       command: ["bash", "-c"]
       args:
         - apt-get -qq update > /dev/null;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -11,6 +11,7 @@ spec:
         - apt-get -qq update > /dev/null;
           apt-get -qq -y install apt-utils > /dev/null;
           apt-get -qq -y install curl > /dev/null;
+          sleep 15;
           echo "=======================";
           echo "Greenwell Site - Health Check";
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -10,12 +10,12 @@ spec:
       args:
         - apt-get -qq update > /dev/null;
           apt-get -qq -y install apt-utils > /dev/null;
-          apt-get -qq -y --no-install-recommends install curl > /dev/null;
+          apt-get -qq -y install curl > /dev/null;
           echo "=======================";
           echo "Greenwell Site - Health Check";
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           echo "=======================";
-          alive=$(curl https://greenwell-app.eu-de.mybluemix.net/health);
+          alive=$(curl -k https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;
           else echo "TEST FAIL - $alive"; exit 1;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   steps:
     - name: task-one-step-one
-      image: ubuntu
+      image: alpine
       command: ["bash", "-c"]
       args:
         - apt-get -qq update > /dev/null;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -8,13 +8,14 @@ spec:
       image: ubuntu
       command: ["bash", "-c"]
       args:
-        - apt-get -qq update > /dev/null;
-          apt-get -qq -y install curl > /dev/null;
-          sleep 15;
-          echo "=======================";
+        - echo "=======================";
           echo "Greenwell Site - Health Check";
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           echo "=======================";
+          sleep 10;
+          apt-get -qq update > /dev/null;
+          apt-get -qq -y install curl > /dev/null;
+          sleep 10;
           alive=$(curl -k https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   steps:
     - name: task-one-step-one
-      image: ubuntu
+      image: centos
       command: ["bash", "-c"]
       args:
         - echo "=======================";

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -11,7 +11,7 @@ spec:
         - echo 'Greenwell Site - Health Check';
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           sleep 15;
-          apt-get -qq update > /dev/null; apt-get -qq -y install --no-install-recommends apt-utils > /dev/null; apt-get -qq -y install curl > /dev/null;
+          apt-get -qq update > /dev/null; apt-get -qq -y --no-install-recommends install apt-utils > /dev/null; apt-get -qq -y --no-install-recommends install curl > /dev/null;
           alive=$(curl https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -12,9 +12,8 @@ spec:
           echo "Greenwell Site - Health Check";
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           echo "=======================";
-          sleep 10;
-          apt-get -qq update; apt-get -qq -y install curl;
-          sleep 10;
+          dnf list installed;
+          dnf -y install curl;
           alive=$(curl -k https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -8,16 +8,15 @@ spec:
       image: ubuntu
       command: ["bash", "-c"]
       args:
-        - echo "Greenwell Site - Health Check";
-          echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
-          sleep 15;
-          echo "Sleep complete";
-          apt-get -qq update;
+        - apt-get -qq update;
           echo "apt-get update complete";
           apt-get -qq -y install apt-utils;
           echo "apt-utils install complete";
           apt-get -qq -y install curl;
           echo "curl install complete";
+          echo "=======================";
+          echo "Greenwell Site - Health Check";
+          echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           alive=$(curl https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   steps:
     - name: task-one-step-one
-      image: alpine
+      image: ubuntu
       command: ["bash", "-c"]
       args:
         - echo "=======================";

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -13,8 +13,7 @@ spec:
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           echo "=======================";
           sleep 10;
-          apt-get -qq update > /dev/null;
-          apt-get -qq -y install curl > /dev/null;
+          apt-get -qq update; apt-get -qq -y install curl;
           sleep 10;
           alive=$(curl -k https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -10,9 +10,9 @@ spec:
       args:
         - apt-get -qq update;
           echo "apt-get update complete";
-          apt-get -qq -y install apt-utils;
+          apt-get -qq -y install apt-utils 2> >( grep -v 'debconf: delaying package configuration, since apt-utils is not installed' >&2 );
           echo "apt-utils install complete";
-          apt-get -qq -y install curl;
+          apt-get -qq -y --no-install-recommends install curl;
           echo "curl install complete";
           echo "=======================";
           echo "Greenwell Site - Health Check";

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -13,6 +13,7 @@ spec:
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           echo "=======================";
           alive=$(curl -k https://greenwell-app.eu-de.mybluemix.net/health);
+          echo "=======================";
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;
           else echo "TEST FAIL - $alive"; exit 1;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -14,7 +14,7 @@ spec:
           echo "=======================";
           alive=$(curl -s -S -k https://greenwell-app.eu-de.mybluemix.net/health);
           echo "=======================";
-          echo $alive
+          echo $alive;
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;
           else echo "TEST FAIL - $alive"; exit 1;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   steps:
     - name: task-one-step-one
-      image: alpine
+      image: debian
       command: ["bash", "-c"]
       args:
         - apt-get -qq update > /dev/null;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -12,9 +12,7 @@ spec:
           echo "Greenwell Site - Health Check";
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           echo "=======================";
-          alive=$(curl -s -S -k https://greenwell-app.eu-de.mybluemix.net/health);
-          echo "=======================";
-          echo $alive;
+          alive=$(curl -s -S -k https://greenwell-app.eu-de.mybluemix.net/health404);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;
           else echo "TEST FAIL - $alive"; exit 1;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -8,10 +8,16 @@ spec:
       image: ubuntu
       command: ["bash", "-c"]
       args:
-        - echo 'Greenwell Site - Health Check';
+        - echo "Greenwell Site - Health Check";
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           sleep 15;
-          apt-get -qq update > /dev/null; apt-get -qq -y --no-install-recommends install apt-utils > /dev/null; apt-get -qq -y --no-install-recommends install curl > /dev/null;
+          echo "Sleep complete";
+          apt-get -qq update;
+          echo "apt-get update complete";
+          apt-get -qq -y install apt-utils;
+          echo "apt-utils install complete";
+          apt-get -qq -y install curl;
+          echo "curl install complete";
           alive=$(curl https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   steps:
     - name: task-one-step-one
-      image: ubuntu
+      image: alpine
       command: ["bash", "-c"]
       args:
         - echo "=======================";

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -9,7 +9,6 @@ spec:
       command: ["bash", "-c"]
       args:
         - apt-get -qq update > /dev/null;
-          apt-get -qq -y install apt-utils > /dev/null;
           apt-get -qq -y install curl > /dev/null;
           sleep 15;
           echo "=======================";


### PR DESCRIPTION
Switch from ubuntu image to centos. This provides for a more reliable output, as curl is installed by default in centos image. 