### PR TITLE
Slow script down for E2E

### DIFF
--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -13,6 +13,7 @@ spec:
           echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
           echo "Endpoint - https://greenwell-app.eu-de.mybluemix.net/health";
           echo "=======================";
+          sleep 30;
           alive=$(curl -s -S -k https://greenwell-app.eu-de.mybluemix.net/health);
           if [ "$alive" == "200 - Healthy" ];
           then echo "TEST PASS - 200"; exit 0;


### PR DESCRIPTION
E2E was failing as the pipelinRun finished too quickly, so the test couldnt STOP it mid-run