### PR TITLE
Add key protect branch

### DIFF
--- a/.tekton/listener.yaml
+++ b/.tekton/listener.yaml
@@ -4,7 +4,7 @@ metadata:
   name: key-protect-test-template
 spec:
   params:
-    - name: e2e_key_protect_api_key
+    - name: key_protect_apikey
       description: api key property
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
@@ -17,8 +17,8 @@ spec:
         pipelineRef:
           name: key-protect-test-pipeline
         params:
-          - name: e2e_key_protect_api_key
-            value: $(params.e2e_key_protect_api_key)
+          - name: key_protect_apikey
+            value: $(params.key_protect_apikey)
 ---
 apiVersion: tekton.dev/v1beta1
 kind: TriggerBinding

--- a/.tekton/listener.yaml
+++ b/.tekton/listener.yaml
@@ -4,7 +4,7 @@ metadata:
   name: key-protect-test-template
 spec:
   params:
-    - name: key_protect_apikey
+    - name: key-protect-apikey
       description: api key property
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
@@ -17,8 +17,8 @@ spec:
         pipelineRef:
           name: key-protect-test-pipeline
         params:
-          - name: key_protect_apikey
-            value: $(params.key_protect_apikey)
+          - name: key-protect-apikey
+            value: $(params.key-protect-apikey)
 ---
 apiVersion: tekton.dev/v1beta1
 kind: TriggerBinding

--- a/.tekton/listener.yaml
+++ b/.tekton/listener.yaml
@@ -1,89 +1,37 @@
 apiVersion: tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
-  name: pipeline-template
+  name: key-protect-test-template
 spec:
   params:
-    - name: gitrevision
-      description: The git revision
-      default: master
-    - name: gitrepositoryurl
-      description: The git repository url
-    - name: message
-      description: The message to print
-      default: This is the default message
+    - name: e2e_key_protect_api_key
+      description: api key property
   resourcetemplates:
-    - apiVersion: tekton.dev/v1beta1
-      kind: PipelineResource
-      metadata:
-        name: git-source-$(uid)
-        labels:
-          triggertemplated: "true"
-          generatedBy: "triggers-example"
-      spec:
-        type: git
-        params:
-          - name: revision
-            value: $(params.gitrevision)
-          - name: url
-            value: $(params.gitrepositoryurl)
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
-        generateName: sample-pipeline-run-$(uid)
+        generateName: key-protect-test-
         labels:
           triggertemplated: "true"
-          generatedBy: "triggers-example"
       spec:
         pipelineRef:
-          name: sample-pipeline
+          name: key-protect-test-pipeline
+        params:
+          - name: e2e_key_protect_api_key
+            value: $(params.e2e_key_protect_api_key)
 ---
 apiVersion: tekton.dev/v1beta1
 kind: TriggerBinding
 metadata:
-  name: pipeline-binding
-spec:
-  params:
-    - name: gitrevision
-      value: $(event.head_commit.id)
-    - name: gitrepositoryurl
-      value: $(event.repository.url)
----
-apiVersion: tekton.dev/v1beta1
-kind: TriggerBinding
-metadata:
-  name: manual-pipeline-binding
-spec:
-  params:
-    - name: gitrevision
-      value: v0.32.0
-    - name: gitrepositoryurl
-      value: https://github.com/GoogleContainerTools/skaffold
+  name: key-protect-test-binding
 ---
 apiVersion: tekton.dev/v1beta1
 kind: EventListener
 metadata:
-  name: listener
+  name: key-protect-test-listener
 spec:
   triggers:
     - binding:
-        name: pipeline-binding
+        name: key-protect-test-binding
       template:
-        name: pipeline-template
-      params:
-        - name: message
-          value: Hello from the Git Triggers EventListener!
----
-apiVersion: tekton.dev/v1beta1
-kind: EventListener
-metadata:
-  name: manual-listener
-spec:
-  triggers:
-    - binding:
-        name: manual-pipeline-binding
-      template:
-        name: pipeline-template
-      params:
-        - name: message
-          value: Hello from the Manual Triggers EventListener!
+        name: key-protect-test-template

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -4,12 +4,12 @@ metadata:
   name: key-protect-test-pipeline
 spec:
   params:
-    - name: e2e_key_protect_api_key
+    - name: key_protect_apikey
       description: api key property
   tasks:
     - name: key-protect
       taskRef:
         name: key-protect
       params:
-        - name: e2e_key_protect_api_key
-          value: $(params.e2e_key_protect_api_key)
+        - name: key_protect_apikey
+          value: $(params.key_protect_apikey)

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -1,9 +1,15 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: sample-pipeline
+  name: key-protect-test-pipeline
 spec:
+  params:
+    - name: e2e_key_protect_api_key
+      description: api key property
   tasks:
-    - name: task1
+    - name: key-protect
       taskRef:
-        name: task1
+        name: key-protect
+      params:
+        - name: e2e_key_protect_api_key
+          value: $(params.e2e_key_protect_api_key)

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -4,12 +4,12 @@ metadata:
   name: key-protect-test-pipeline
 spec:
   params:
-    - name: key_protect_apikey
+    - name: key-protect-apikey
       description: api key property
   tasks:
     - name: key-protect
       taskRef:
         name: key-protect
       params:
-        - name: key_protect_apikey
-          value: $(params.key_protect_apikey)
+        - name: key-protect-apikey
+          value: $(params.key-protect-apikey)

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -11,7 +11,7 @@ spec:
       image: ibmcom/pipeline-base-image:2.9
       env:
         - name: KEY_PROTECT_APIKEY
-          value: $(params.key-protect-apikey)
+          value: $(input.params.key-protect-apikey)
       command: ["bash", "-c"]
       args:
         - |

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -11,7 +11,7 @@ spec:
       image: ibmcom/pipeline-base-image:2.9
       env:
         - name: KEY_PROTECT_APIKEY
-          value: $(input.params.key-protect-apikey)
+          value: $(inputs.params.key-protect-apikey)
       command: ["bash", "-c"]
       args:
         - |

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -4,19 +4,19 @@ metadata:
   name: key-protect
 spec:
   params:
-    - name: key_protect_apikey
+    - name: key-protect-apikey
       description: api key property
   steps:
     - name: key-protect-test
       image: ibmcom/pipeline-base-image:2.9
       env:
-        - name: key_protect_apikey
-          value: $(inputs.params.key_protect_apikey)
+        - name: key-protect-apikey
+          value: $(params.key-protect-apikey)
       command: ["bash", "-c"]
       args:
         - |
           #!/usr/bin/env bash
           echo "Key Protect Test"
           echo "================"
-          echo "apikey: ${key_protect_apikey}"
-          ibmcloud login --apikey ${key_protect_apikey} --no-region
+          echo "apikey: ${key-protect-apikey}"
+          ibmcloud login --apikey ${key-protect-apikey} --no-region

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -4,18 +4,19 @@ metadata:
   name: key-protect
 spec:
   params:
-    - name: e2e_key_protect_api_key
+    - name: key_protect_apikey
       description: api key property
   steps:
     - name: key-protect-test
       image: ibmcom/pipeline-base-image:2.9
       env:
-        - name: E2E_KEY_PROTECT_API_KEY
-          value: $(inputs.params.e2e_key_protect_api_key)
+        - name: key_protect_apikey
+          value: $(inputs.params.key_protect_apikey)
       command: ["bash", "-c"]
       args:
         - |
           #!/usr/bin/env bash
           echo "Key Protect Test"
           echo "================"
-          ibmcloud login --apikey ${E2E_KEY_PROTECT_API_KEY} --no-region
+          echo "apikey: ${key_protect_apikey}"
+          ibmcloud login --apikey ${key_protect_apikey} --no-region

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -1,21 +1,21 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: task1
+  name: key-protect
 spec:
+  params:
+    - name: e2e_key_protect_api_key
+      description: api key property
   steps:
-    - name: task-one-step-one
-      image: centos
+    - name: key-protect-test
+      image: ibmcom/pipeline-base-image:2.9
+      env:
+        - name: E2E_KEY_PROTECT_API_KEY
+          value: $(inputs.params.e2e_key_protect_api_key)
       command: ["bash", "-c"]
       args:
-        - echo "=======================";
-          echo "Greenwell Site - Health Check";
-          echo "Using https://github.com/ziheng-c/greenwell-tekton.git";
-          echo "Endpoint - https://greenwell-app.eu-de.mybluemix.net/health";
-          echo "=======================";
-          sleep 60;
-          alive=$(curl -s -S -k https://greenwell-app.eu-de.mybluemix.net/health);
-          if [ "$alive" == "200 - Healthy" ];
-          then echo "TEST PASS - 200"; exit 0;
-          else echo "TEST FAIL - $alive"; exit 1;
-          fi
+        - |
+          #!/usr/bin/env bash
+          echo "Key Protect Test"
+          echo "================"
+          ibmcloud login --apikey ${E2E_KEY_PROTECT_API_KEY} --no-region

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -10,7 +10,7 @@ spec:
     - name: key-protect-test
       image: ibmcom/pipeline-base-image:2.9
       env:
-        - name: key-protect-apikey
+        - name: KEY_PROTECT_APIKEY
           value: $(params.key-protect-apikey)
       command: ["bash", "-c"]
       args:
@@ -18,5 +18,5 @@ spec:
           #!/usr/bin/env bash
           echo "Key Protect Test"
           echo "================"
-          echo "apikey: ${key-protect-apikey}"
-          ibmcloud login --apikey ${key-protect-apikey} --no-region
+          echo "apikey: ${KEY_PROTECT_APIKEY}"
+          ibmcloud login --apikey ${KEY_PROTECT_APIKEY} --no-region


### PR DESCRIPTION
This branch will be used for a new e2e test to exercise the key protect tool integration for api keys

https://github.ibm.com/org-ids/otc-ui-tests/pull/52